### PR TITLE
[feat]: add logging setUp using Loguru for std output

### DIFF
--- a/python-api/app/core/config.py
+++ b/python-api/app/core/config.py
@@ -18,7 +18,17 @@ class Settings(BaseSettings):
     
     # Security
     SECRET_KEY: str | None = None
-    
+
+    # Integrations
+    GOOGLE_CALENDAR_API_URL: str | None = None
+
+    # Logging
+    LOGS_FILE_NAME: str = "app.log"
+    LOGS_FILE_ROTATION: str = "600 MB"
+    LOGS_FILE_SERIALIZE: bool = False
+    LOGS_LEVEL: str = "DEBUG"
+    ENABLE_LOGGING_FILE: bool = True
+
     class Config:
         env_file = ".env"
         case_sensitive = True

--- a/python-api/app/core/logging.py
+++ b/python-api/app/core/logging.py
@@ -1,0 +1,82 @@
+from loguru import logger
+from loguru._defaults import LOGURU_FORMAT
+import sys
+import logging
+# local imports
+from app.core.config import settings
+
+
+class InterceptHandler(logging.Handler):
+    """
+    A logging handler that intercepts standard Python logging module records
+    and forwards them to Loguru, enabling to use Loguru's advanced logging
+    features while maintaining compatibility with existing logging infrastructure.
+
+    Methods
+    -------
+    emit(record: logging.LogRecord) -> None
+        Forwards the log record to Loguru, preserving the log level and exception information.
+
+    References
+    ----------
+    Loguru documentation: https://loguru.readthedocs.io/en/stable/overview.html#entirely-compatible-with-standard-logging
+    """
+    def emit(self, record: logging.LogRecord) -> None:
+        # Get corresponding Loguru level if it exists
+        try:
+            level = logger.level(record.levelname).name
+        except ValueError:
+            level = record.levelno
+
+        logger.opt(depth=_get_log_depth(), exception=record.exc_info).log(
+            level, record.getMessage()
+        )
+
+
+def _get_log_depth() -> int:
+    """
+    Find the correct depth in the call stack to identify the origin of a log message.
+
+    Returns:
+        int: The depth in the call stack where the actual logging call originated,
+        skipping internal frames from the logging module.
+    """
+    frame = logging.currentframe()
+    depth = 1
+    while frame and frame.f_globals.get("__name__") == "logging":
+        frame = frame.f_back
+        depth += 1
+    return depth
+
+
+def configure_logging():
+    """
+    Set up application logging by:
+
+    - Replacing the root logger's handlers with the above custom InterceptHandler
+    to route standard logs to Loguru.
+    - Configuring Loguru to log to stdout with the desired format and log level.
+    - Optionally adding a file sink for logs if enabled in settings, and logging an error if this fails.
+    """
+    logging.getLogger().handlers = [InterceptHandler()]
+
+    # set format for scripts
+    logger.configure(
+        handlers=[{
+            "sink"  : sys.stdout,
+            "level" : settings.LOGS_LEVEL,
+            "format": LOGURU_FORMAT
+        }]
+    )
+
+    try:
+        if settings.ENABLE_LOGGING_FILE:
+            logger.add(
+                settings.LOGS_FILE_NAME,
+                rotation  = settings.LOGS_FILE_ROTATION,
+                backtrace = True,
+                diagnose  = True,
+                serialize = settings.LOGS_FILE_SERIALIZE
+            )
+    except Exception as e:
+        logger.error(f"Failed to add log file sink: {e}")


### PR DESCRIPTION
##What?
Implemented a centralized and logging system using Loguru to handle both application and standard Python logs that includes traceback follows to know the source of the log events.

Why?
To ensure consistent and  friendly logging across the entire google_calendar implementation. This setup simplifies the debugging, process and supports log file rotation at 600 MB  of memory.

How?
- Integrated Loguru with Python’s standard logging module using a custom InterceptHandler from Loguro documentation.
- Configured Loguru to:
    - Output logs to stdout with a default format.
    -  write logs to a file (app.log) with backtrace.
-  ensure log origin tracing.
- Used environment variables settings  in settings.py to control logger configutations.