### PR TITLE
Feature/parse metadata from json

### DIFF
--- a/python-api/app/integrations/google_calendar/parse_calendar_api_data.py
+++ b/python-api/app/integrations/google_calendar/parse_calendar_api_data.py
@@ -1,0 +1,275 @@
+import json
+from loguru import logger
+from typing import Optional
+from app.core.logging import configure_logging
+from app.integrations.google_calendar.schemas.calendar_metadata_schemas import CalendarMetadataParents, ApiMethod, SchemaResolver
+from typing import Tuple, Dict, Any
+
+def load_file_data(json_path: str) -> dict:
+    """
+    Loads JSON data from a specified file path.
+    The file to load contains the  API metadata for Google Calendar.
+    This function reads the JSON file and returns its content as a dictionary.
+
+    Args:
+        json_path (str): The path to the JSON file to be loaded.
+    Returns:
+        dict: The data loaded from the JSON file.
+
+    Raises:
+        FileNotFoundError: If the specified file does not exist.
+        ValueError: If the file contains invalid JSON.
+    """
+    try:
+        logger.debug(f"Loading JSON data from {json_path}")
+
+        with open(json_path, "r") as json_file:
+            return json.load(json_file)
+    except FileNotFoundError:
+        raise FileNotFoundError(f"File not found: {json_path}")
+    except json.JSONDecodeError as e:
+        raise ValueError(f"Invalid JSON format in file {json_path}: {e}")
+
+def extract_top_level_attributes(data: dict) -> CalendarMetadataParents:
+    """
+    Extracts the top-level attributes ('parameters', 'schemas', 'resources')
+    from the Google Calendar API metadata dictionary
+    and returns them as a CalendarMetadataParents object.
+    This function is used to parse the API metadata and prepare it for further processing.
+
+    Args:
+        data (dict): The API metadata dictionary containing top-level attributes
+            including 'parameters', 'schemas', and 'resources'.
+
+    Returns:
+        CalendarMetadataParents: An object containing the extracted 'parameters', 'schemas', and 'resources' attributes.
+    """
+    parent_metadata = CalendarMetadataParents(
+        parameters = data.get("parameters", {}),
+        schemas = data.get("schemas", {}),
+        resources = data.get("resources", {})
+    )
+
+    if not parent_metadata.resources:
+        logger.warning("No resources found in API metadata. Ensure the metadata is correct.")
+        raise ValueError("No resources found in API metadata.")
+
+    logger.debug("Extracted top-level attributes from API metadata.")
+    return parent_metadata
+
+def get_api_resources_with_methods(parent_metadata: CalendarMetadataParents) -> list[dict]:
+    """
+    Extracts and returns a list of resources with their associated methods from
+    the given CalendarMetadataParents object.
+    This function processes the 'resources' attribute of the CalendarMetadataParents object,
+    filtering out resources that do not have a 'methods' attribute or where 'methods' is not a dictionary.
+
+    Each list of resources contains dictionaries with the following keys:
+        - "resource_name" (str): The name of the resource.
+        - "methods" (dict): The methods associated with the resource.
+
+    Args:
+        parent_metadata (CalendarMetadataParents): The metadata object containing API resource definitions.
+
+    Returns:
+        list[dict]: A list of dictionaries, each containing:
+            - "resource_name" (str): The name of the resource.
+            - "methods" (dict): The methods associated with the resource.
+
+    Raises:
+        ValueError: If no resources are found in the metadata, or if no valid resources with methods are found.
+
+    Logs:
+        - Warnings if a resource's "methods" attribute is not a dictionary or if an error occurs while processing a resource.
+        - Debug message indicating the number of resources with methods found.
+    """
+    if not parent_metadata.resources:
+        raise ValueError("No resources with endpoint's documentation found in API metadata.")
+
+    resources_with_methods = []
+
+    for resource_name, resource in parent_metadata.resources.items():
+        try:
+            methods = resource.get("methods", {})
+            if not isinstance(methods, dict):
+                logger.warning(f"'methods' for resource '{resource_name}' is not a dict. Skipping.")
+                continue
+
+            resources_with_methods.append({
+                "resource_name": resource_name,
+                "methods": methods
+            })
+        except Exception as e:
+            logger.warning(f"Error processing resource '{resource_name}': {e}. Skipping.")
+
+    if not resources_with_methods:
+        raise ValueError("No valid resources with methods found in API metadata.")
+
+    logger.debug(f"Found {len(resources_with_methods)} resources with methods.")
+    return resources_with_methods
+
+def get_api_method_parameters(method_parameters: dict):
+    """
+    Extracts and categorizes API method parameters into required and optional 
+    parameters lists.
+    This function processes the 'parameters' attribute of an API method,
+    identifying which parameters are required and which are optional.
+    A parameter is considered required if its value dictionary contains the key "required".
+
+    It returns two lists:
+        - required_params: A list of dictionaries representing required parameters, with the "required" key removed.
+        - optional_params: A list of dictionaries representing optional parameters.
+
+    A parameter contains the next data-contract:
+        {
+            "name": "parameter_name",
+            "type": "string",  # or other types like "integer", "boolean", etc.
+            "description": "A brief description of the parameter",
+            "location": "query"  # or "path", "header", etc.
+        }
+
+    Args:
+        method_parameters (dict): A dictionary where each key is a parameter name and each
+            value is a dictionary describing the parameter's attributes. The presence of the "required"
+            key in the value dictionary determines if the parameter is required.
+    Returns:
+        tuple: A tuple containing two lists:
+            - required_params (list): List of dictionaries representing required parameters (with "required" key removed).
+            - optional_params (list): List of dictionaries representing optional parameters.
+    Notes:
+        - Parameters whose value is not a dictionary are skipped.
+        - If an error occurs while processing a parameter, it is skipped and a warning is logged.
+    """
+    if not method_parameters:
+        return [], []
+
+    required_params = []
+    optional_params = []
+
+    for name, value in method_parameters.items():
+        if not isinstance(value, dict):
+            continue  # Skip if value is not a dict
+
+        try:
+            parameter_dict = {"name": name, **value}
+            if "required" in parameter_dict:
+                parameter_dict.pop("required")
+                required_params.append(parameter_dict)
+            else:
+                optional_params.append(parameter_dict)
+        except Exception as e:
+            logger.warning(f"Error processing parameter '{name}': {e}. Skip it.")
+
+    return required_params, optional_params
+
+def get_request_response_schemas(
+    method: dict, schemas_resolver: SchemaResolver
+) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    """
+    Extracts and resolves request and response schema attributes from an API method definition.
+    Given a method dictionary and a SchemaResolver instance, this function attempts to resolve
+    any schema references ("$ref") found in the "request" and "response" attributes of the method.
+    If a reference is found, it is resolved using the provided SchemaResolver. If resolution fails,
+    the unresolved reference is retained. If no schema is present, empty dictionaries are returned.
+
+    Args:
+        method (dict): The API method definition containing "request" and/or "response" attributes.
+        schemas_resolver (SchemaResolver): An instance capable of resolving schema references.
+
+    Returns:
+        Tuple[Dict[str, Any], Dict[str, Any]]: A tuple containing the processed request and response
+        attribute dictionaries, with resolved schemas if applicable.
+
+    Example:
+    >>> method = {
+        "request": {"$ref": "RequestSchema"},
+        "response": {"$ref": "ResponseSchema"}
+    }
+    """
+    request_attrs = method.get("request", {})
+    response_attrs = method.get("response", {})
+
+    try:
+        if request_attrs:
+            if "$ref" in request_attrs:
+                ref_schema = request_attrs.pop("$ref")
+                try:
+                    request_attrs["schema"] = schemas_resolver.get_resolved(ref_schema)
+                except Exception as e:
+                    logger.warning(f"Failed to resolve request schema ref '{ref_schema}': {e}")
+                    request_attrs["schema"] = ref_schema
+
+        if response_attrs:
+            if "$ref" in response_attrs:
+                ref_schema = response_attrs.pop("$ref")
+                try:
+                    response_attrs["schema"] = schemas_resolver.get_resolved(ref_schema)
+                except Exception as e:
+                    logger.warning(f"Failed to resolve response schema ref '{ref_schema}': {e}")
+                    response_attrs["schema"] = ref_schema
+
+        return request_attrs, response_attrs
+    except Exception as e:
+        logger.warning(f"Error processing request/response schemas: {e}")
+        return {}, {}
+
+def get_api_methods(resources_with_methods: list[dict], schemas_resolver: SchemaResolver) -> Optional[list[ApiMethod]]:
+    """
+    Extracts and formats API method information from a list of resource dictionaries.
+    Each resource dictionary is expected to contain a "resource_name" and a "methods" dictionary.
+
+    Iterates through each resource, processes its methods, and constructs a list of `ApiMethod` objects
+    containing relevant metadata such as HTTP method, path, parameters, and request/response schemas.
+
+    Args:
+        resources_with_methods (list[dict]): 
+            A list of dictionaries, each representing an API resource with its associated methods.
+        schemas_resolver (SchemaResolver): 
+            An instance used to resolve request and response schemas for each API method.
+
+    Returns:
+        Optional[list[ApiMethod]]: 
+            A list of formatted `ApiMethod` objects if any are found, otherwise an empty list.
+            Returns None if no valid API methods are processed.
+    """
+
+    logger.debug("Formatting API endpoints from resources with methods.")
+    formatted_api_endpoints = []
+
+    for resource in resources_with_methods:
+        if not isinstance(resource, dict):
+            logger.warning(f"Resource is not a dict: {resource}. Skipping resource.")
+            continue
+    
+        try:
+            resource_name = resource["resource_name"]
+            methods = resource["methods"]
+        except KeyError as e:
+            logger.warning(f"Missing key in resource: {e}. Skipping resource.")
+            continue
+
+        for method_name, method in methods.items():
+            try:
+                required_params, optional_params = get_api_method_parameters(method.get("parameters", {}))
+                request_schema, response_schema = get_request_response_schemas(method, schemas_resolver)
+
+                current_method = ApiMethod(
+                    resource_name = resource_name,
+                    method_name = method_name,
+                    http_method = method.get("httpMethod", ""),
+                    path = method.get("path", ""),
+                    description = method.get("description", ""),
+                    required_params = required_params,
+                    optional_params = optional_params,
+                    parameter_order = method.get("parameterOrder", []),
+                    request_schema = request_schema,
+                    response_schema = response_schema
+                )
+
+                formatted_api_endpoints.append(current_method)
+            except Exception as e:
+                logger.warning(f"Error processing method '{method_name}' in resource '{resource_name}': {e}. Skipping method.")
+                continue
+
+    logger.debug(f"Formatted {len(formatted_api_endpoints)} API methods.")
+    return formatted_api_endpoints

--- a/python-api/app/integrations/google_calendar/schemas/calendar_metadata_schemas.py
+++ b/python-api/app/integrations/google_calendar/schemas/calendar_metadata_schemas.py
@@ -1,0 +1,115 @@
+from typing import List, Optional, Dict, Any, Union
+from pydantic import BaseModel
+
+
+class SchemaResolver:
+    """
+    SchemaResolver is a utility class for Google Calendar API metadata schemas.
+    Those schemas comes from the response of the metadata request, and can contains
+    "$ref" configutaions wich we need to resolve.
+
+    Attributes:
+        schemas (Dict[str, Any]): A dictionary mapping schema names found on API response to their definitions.
+        resolved_schemas (Dict[str, Dict[str, Any]]): A cache of schemas that have been fully resolved.
+
+    Methods:
+        __init__(schemas: Dict[str, Any]) -> None:
+            Initializes the SchemaResolver with a dictionary of schemas.
+
+        get_resolved(schema_name: str) -> Optional[Dict[str, Any]]:
+            Retrieves a resolved schema by its name from the cache, if available.
+
+        resolve_all() -> None:
+            Resolves all schemas in the provided dictionary, expanding any nested $ref references, and stores them in the cache.
+
+        _resolve_schema(schema: Dict[str, Any], seen: set[str] = None) -> Dict[str, Any]:
+            Recursively resolves a schema, expanding all $ref references. Handles circular references by tracking seen references.
+    """
+    def __init__(self, schemas: Dict[str, Any]) -> None:
+        self.schemas = schemas
+        self.resolved_schemas: Dict[str, Dict[str, Any]] = {}
+
+    def get_resolved(self, schema_name: str) -> Optional[Dict[str, Any]]:
+        return self.resolved_schemas.get(schema_name)
+
+    def resolve_all(self) -> None:
+        for schema_name in self.schemas:
+            self.resolved_schemas[schema_name] = self._resolve_schema(self.schemas[schema_name])
+
+    def _resolve_schema(self, schema: Dict[str, Any], seen: set[str] = None) -> Dict[str, Any]:
+        """
+        Recursively resolve a schema and all its nested $ref entries.
+        """
+        if seen is None:
+            seen = set()
+
+        if isinstance(schema, list):
+            return [self._resolve_schema(item, seen) for item in schema]
+
+        if not isinstance(schema, dict):
+            return schema  # value is not a dict, return as is
+
+        if "$ref" in schema:
+            ref_value = schema["$ref"]
+
+            if ref_value in seen:
+                # Avoid circular references
+                return {"$ref": ref_value}
+
+            seen.add(ref_value)
+            ref_schema = self.schemas.get(ref_value)
+
+            if not ref_schema:
+                return {"$ref": ref_value}  # unresolved
+
+            return self._resolve_schema(ref_schema, seen)
+
+        resolved = {}
+        for key, value in schema.items():
+            resolved[key] = self._resolve_schema(value, seen.copy())
+        return resolved
+
+
+class CalendarMetadataParents(BaseModel):
+    """
+    Represents metadata top-level information for calendar parents in the Google Calendar integration.
+
+    Attributes:
+        parameters (Optional[dict]): Additional parameters related to the calendar metadata.
+        schemas (Optional[dict]): Schema definitions associated with the calendar metadata.
+        resources (Optional[dict]): Resource information relevant to the calendar metadata.
+    """
+    parameters: Optional[dict]
+    schemas: Optional[dict]
+    resources: Optional[dict]
+
+
+class ApiMethod(BaseModel):
+    """
+    Represents the metadata for an API endpoint method in the
+    Google Calendar integration.
+
+    Attributes:
+        resource_name (str): The name of the resource the API method operates on.
+        method_name (str): The name of the API method.
+        http_method (str): The HTTP method used (e.g., 'GET', 'POST').
+        path (str): The endpoint path for the API method.
+        description (Optional[str]): A brief description of the API method.
+        required_params (List[dict]): A list of dictionaries describing required parameters for the method.
+        optional_params (List[dict]): A list of dictionaries describing optional parameters for the method.
+        parameter_order (List[str]): The order in which parameters should be provided.
+        request_schema (Optional[dict]): The schema for the request payload, if applicable.
+        response_schema (Optional[dict]): The schema for the response payload, if applicable.
+    """
+    resource_name: str
+    method_name: str
+    http_method: str
+    path: str
+    description: Optional[str]
+    required_params: List[dict]
+    optional_params: List[dict]
+    parameter_order: List[str]
+    request_schema: Optional[dict]
+    response_schema: Optional[dict]
+
+

--- a/python-api/app/integrations/google_calendar/tests/test_parse_calendar_api_data.py
+++ b/python-api/app/integrations/google_calendar/tests/test_parse_calendar_api_data.py
@@ -1,0 +1,413 @@
+import os
+import tempfile
+import json
+import pytest
+from app.integrations.google_calendar.parse_calendar_api_data import load_file_data, extract_top_level_attributes, get_api_resources_with_methods, get_api_method_parameters, get_request_response_schemas, get_api_methods
+from app.integrations.google_calendar.schemas.calendar_metadata_schemas import CalendarMetadataParents, ApiMethod
+
+
+DUMMY_JSON = {
+    "revision": "20250611",
+    "resources": {
+        "acl": {
+            "methods": {
+                "delete": {
+                    "id": "calendar.acl.delete",
+                    "path": "calendars/{calendarId}/acl/{ruleId}",
+                    "httpMethod": "DELETE",
+                    "description": "Deletes an access control rule.",
+                    "parameters": {
+                        "calendarId": {
+                            "type": "string",
+                            "description": "Calendar identifier. To retrieve calendar IDs call the calendarList.list method. If you want to access the primary calendar of the currently logged in user, use the \"primary\" keyword.",
+                            "required": True,
+                            "location": "path"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+def test_load_file_data_valid_json():
+    data = DUMMY_JSON
+    with tempfile.NamedTemporaryFile(mode="w+", delete=False) as tmp:
+        json.dump(data, tmp)
+        tmp_path = tmp.name
+    try:
+        result = load_file_data(tmp_path)
+        assert result == data
+    finally:
+        os.remove(tmp_path)
+
+def test_load_file_data_file_not_found():
+    with pytest.raises(FileNotFoundError):
+        load_file_data("non_existent_file.json")
+
+def test_load_file_data_invalid_json():
+    with tempfile.NamedTemporaryFile(mode="w+", delete=False) as tmp:
+        tmp.write("{invalid_json: true,}")  # malformed JSON
+        tmp_path = tmp.name
+    try:
+        with pytest.raises(ValueError):
+            load_file_data(tmp_path)
+    finally:
+        os.remove(tmp_path)
+        
+def test_extract_top_level_attributes_all_present():
+    data = DUMMY_JSON
+    result = extract_top_level_attributes(data)
+    assert result.parameters == {}
+    assert result.schemas == {}
+    assert result.resources == DUMMY_JSON["resources"]
+
+def test_extract_top_level_attributes_with_all_keys():
+    data = {
+        "parameters": {"foo": "bar"},
+        "schemas": {"baz": "qux"},
+        "resources": DUMMY_JSON["resources"]
+    }
+    result = extract_top_level_attributes(data)
+    assert result.parameters == {"foo": "bar"}
+    assert result.schemas == {"baz": "qux"}
+    assert result.resources == DUMMY_JSON["resources"]
+
+def test_extract_top_level_attributes_missing_parameters_and_schemas():
+    data = {
+        "resources": DUMMY_JSON["resources"]
+    }
+    result = extract_top_level_attributes(data)
+    assert result.parameters == {}
+    assert result.schemas == {}
+    assert result.resources == DUMMY_JSON["resources"]
+
+def test_extract_top_level_attributes_missing_resources_raises():
+    data = {
+        "parameters": {"foo": "bar"},
+        "schemas": {"baz": "qux"}
+    }
+    with pytest.raises(ValueError, match="No resources found in API metadata."):
+        extract_top_level_attributes(data)
+
+def test_extract_top_level_attributes_empty_resources_raises():
+    data = {
+        "parameters": {},
+        "schemas": {},
+        "resources": {}
+    }
+    with pytest.raises(ValueError, match="No resources found in API metadata."):
+        extract_top_level_attributes(data)
+
+def test_get_api_resources_with_methods_basic():
+
+    parent_metadata = CalendarMetadataParents(
+        parameters={},
+        schemas={},
+        resources=DUMMY_JSON["resources"]
+    )
+
+    result = get_api_resources_with_methods(parent_metadata)
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert "delete" in result[0]["methods"]
+    assert result[0]["methods"]["delete"]["id"] == "calendar.acl.delete"
+
+def test_get_api_resources_with_methods_skips_non_dict_methods():
+
+    data = DUMMY_JSON.copy()
+    data['resources']['methods'] = ["not", "a", "dict"]
+
+    parent_metadata = CalendarMetadataParents(
+        parameters={},
+        schemas={},
+        resources=data['resources']
+    )
+
+    result = get_api_resources_with_methods(parent_metadata)
+    assert len(result) == 1
+    assert result[0]["resource_name"] == "acl"
+
+def test_get_api_resources_with_methods_empty_resources_raises():
+
+    parent_metadata = CalendarMetadataParents(parameters={}, schemas={}, resources={})
+    with pytest.raises(ValueError, match="No resources with endpoint's documentation found in API metadata."):
+        get_api_resources_with_methods(parent_metadata)
+
+def test_get_api_resources_with_methods_no_valid_methods_raises():
+
+    parent_metadata = CalendarMetadataParents(
+        parameters={},
+        schemas={},
+        resources={
+            "acl": {
+                "methods": ["not", "a", "dict"]
+            }
+        }
+    )
+    with pytest.raises(ValueError, match="No valid resources with methods found in API metadata."):
+        get_api_resources_with_methods(parent_metadata)
+
+def test_get_api_resources_with_methods_handles_exceptions_gracefully(monkeypatch):
+
+    class BadDict(dict):
+        def get(self, *args, **kwargs):
+            raise Exception("bad get")
+
+    parent_metadata = CalendarMetadataParents(
+        parameters={},
+        schemas={},
+        resources={
+            "bad_resource": BadDict()
+        }
+    )
+    # Should raise ValueError because no valid resources with methods are found
+    with pytest.raises(ValueError, match="No valid resources with methods found in API metadata."):
+        get_api_resources_with_methods(parent_metadata)
+        
+def test_get_api_method_parameters_empty():
+    required, optional = get_api_method_parameters({})
+    assert required == []
+    assert optional == []
+
+def test_get_api_method_parameters_none():
+    required, optional = get_api_method_parameters(None)
+    assert required == []
+    assert optional == []
+
+def test_get_api_method_parameters_required_and_optional():
+    params = {
+        "calendarId": {
+            "type": "string",
+            "description": "Calendar identifier.",
+            "required": True,
+            "location": "path"
+        },
+        "maxResults": {
+            "type": "integer",
+            "description": "Maximum number of entries returned on one result page.",
+            "location": "query"
+        }
+    }
+    required, optional = get_api_method_parameters(params)
+    assert len(required) == 1
+    assert required[0]["name"] == "calendarId"
+    assert "required" not in required[0]
+    assert required[0]["type"] == "string"
+    assert len(optional) == 1
+    assert optional[0]["name"] == "maxResults"
+    assert optional[0]["type"] == "integer"
+
+def test_get_api_method_parameters_skips_non_dict():
+    params = {
+        "calendarId": "should be dict",
+        "maxResults": {
+            "type": "integer",
+            "description": "Maximum number of entries.",
+            "location": "query"
+        }
+    }
+    required, optional = get_api_method_parameters(params)
+    assert required == []
+    assert len(optional) == 1
+    assert optional[0]["name"] == "maxResults"
+
+def test_get_api_method_parameters_required_key_false():
+    params = {
+        "calendarId": {
+            "type": "string",
+            "description": "Calendar identifier.",
+            "required": False,
+            "location": "path"
+        }
+    }
+    required, optional = get_api_method_parameters(params)
+    # Even if required is False, it is treated as required and removed from dict
+    assert len(required) == 1
+    assert required[0]["name"] == "calendarId"
+    assert "required" not in required[0]
+    assert optional == []
+
+def test_get_api_method_parameters_handles_exception(monkeypatch):
+    class BadDict(dict):
+        def items(self):
+            raise Exception("bad items")
+    params = BadDict()
+    required, optional = get_api_method_parameters(params)
+    assert required == []
+    assert optional == []
+
+def test_get_request_response_schemas_no_refs():
+    method = {
+        "request": {"type": "object", "description": "Request body"},
+        "response": {"type": "object", "description": "Response body"}
+    }
+    class DummyResolver:
+        def get_resolved(self, ref):
+            return {"resolved": ref}
+    req, resp = get_request_response_schemas(method, DummyResolver())
+    assert req == {"type": "object", "description": "Request body"}
+    assert resp == {"type": "object", "description": "Response body"}
+
+def test_get_request_response_schemas_with_refs():
+    method = {
+        "request": {"$ref": "RequestSchema"},
+        "response": {"$ref": "ResponseSchema"}
+    }
+    class DummyResolver:
+        def get_resolved(self, ref):
+            return {"resolved": ref}
+    req, resp = get_request_response_schemas(method, DummyResolver())
+    assert req["schema"] == {"resolved": "RequestSchema"}
+    assert resp["schema"] == {"resolved": "ResponseSchema"}
+
+def test_get_request_response_schemas_with_ref_resolution_failure(monkeypatch):
+    method = {
+        "request": {"$ref": "RequestSchema"},
+        "response": {"$ref": "ResponseSchema"}
+    }
+    class FailingResolver:
+        def get_resolved(self, ref):
+            raise Exception("fail")
+    req, resp = get_request_response_schemas(method, FailingResolver())
+    assert req["schema"] == "RequestSchema"
+    assert resp["schema"] == "ResponseSchema"
+
+def test_get_request_response_schemas_empty_method():
+    class DummyResolver:
+        def get_resolved(self, ref):
+            return {"resolved": ref}
+    req, resp = get_request_response_schemas({}, DummyResolver())
+    assert req == {}
+    assert resp == {}
+
+def test_get_api_methods_basic():
+    class DummyResolver:
+        def get_resolved(self, ref):
+            return {"resolved": ref}
+
+    resources_with_methods = [
+        {
+            "resource_name": "acl",
+            "methods": {
+                "delete": {
+                    "id": "calendar.acl.delete",
+                    "path": "calendars/{calendarId}/acl/{ruleId}",
+                    "httpMethod": "DELETE",
+                    "description": "Deletes an access control rule.",
+                    "parameters": {
+                        "calendarId": {
+                            "type": "string",
+                            "description": "Calendar identifier.",
+                            "required": True,
+                            "location": "path"
+                        }
+                    }
+                }
+            }
+        }
+    ]
+
+    result = get_api_methods(resources_with_methods, DummyResolver())
+    assert isinstance(result, list)
+    assert len(result) == 1
+    method = result[0]
+    assert isinstance(method, ApiMethod)
+    assert method.resource_name == "acl"
+    assert method.method_name == "delete"
+    assert method.http_method == "DELETE"
+    assert method.path == "calendars/{calendarId}/acl/{ruleId}"
+    assert method.description.startswith("Deletes")
+    assert method.required_params[0]["name"] == "calendarId"
+    assert method.optional_params == []
+    assert method.request_schema == {}
+    assert method.response_schema == {}
+
+def test_get_api_methods_with_schema_refs():
+    class DummyResolver:
+        def get_resolved(self, ref):
+            return {"resolved": ref}
+
+    resources_with_methods = [
+        {
+            "resource_name": "events",
+            "methods": {
+                "insert": {
+                    "id": "calendar.events.insert",
+                    "path": "calendars/{calendarId}/events",
+                    "httpMethod": "POST",
+                    "description": "Creates an event.",
+                    "parameters": {},
+                    "request": {"$ref": "EventRequest"},
+                    "response": {"$ref": "EventResponse"}
+                }
+            }
+        }
+    ]
+
+    result = get_api_methods(resources_with_methods, DummyResolver())
+    assert len(result) == 1
+    method = result[0]
+    assert method.request_schema["schema"] == {"resolved": "EventRequest"}
+    assert method.response_schema["schema"] == {"resolved": "EventResponse"}
+
+def test_get_api_methods_handles_non_dict_resource():
+    class DummyResolver:
+        def get_resolved(self, ref):
+            return {"resolved": ref}
+
+    resources_with_methods = [
+        "not_a_dict"
+    ]
+
+    result = get_api_methods(resources_with_methods, DummyResolver())
+    assert result == []
+
+def test_get_api_methods_missing_keys():
+    class DummyResolver:
+        def get_resolved(self, ref):
+            return {"resolved": ref}
+
+    resources_with_methods = [
+        {"methods": {}}  # missing resource_name
+    ]
+
+    result = get_api_methods(resources_with_methods, DummyResolver())
+    assert result == []
+
+def test_get_api_methods_method_processing_exception(monkeypatch):
+    class DummyResolver:
+        def get_resolved(self, ref):
+            return {"resolved": ref}
+
+    # Patch get_api_method_parameters to raise
+    import app.integrations.google_calendar.parse_calendar_api_data as mod
+
+    def bad_get_api_method_parameters(params):
+        raise Exception("fail")
+
+    monkeypatch.setattr(mod, "get_api_method_parameters", bad_get_api_method_parameters)
+
+    resources_with_methods = [
+        {
+            "resource_name": "acl",
+            "methods": {
+                "delete": {
+                    "id": "calendar.acl.delete",
+                    "path": "calendars/{calendarId}/acl/{ruleId}",
+                    "httpMethod": "DELETE",
+                    "description": "Deletes an access control rule.",
+                    "parameters": {}
+                }
+            }
+        }
+    ]
+    result = mod.get_api_methods(resources_with_methods, DummyResolver())
+    assert result == []
+
+def test_get_api_methods_empty_input():
+    class DummyResolver:
+        def get_resolved(self, ref):
+            return {"resolved": ref}
+    result = get_api_methods([], DummyResolver())
+    assert result == []


### PR DESCRIPTION
## What?
- Add feature functions to  parsing the saved Google Calendar API Discovery JSON file into structured Pydantic models.
- Introduced  parsing logic to extract resources, methods, parameters, and resolve $ref schemas.
- Defined `CalendarMetadataParents` and `ApiMethod` Pydantic models.
- Added `SchemaResolver` utility to recursively resolve nested `($ref)` and referenced schemas within the API spec.

## Why?
- To prepares structured metadata on pydantic schemas that will be injected to a CSV file.
- Validates API discovery data into clean Python objects for  further transformation.

## How?
- Added `parse_calendar_api_metadata.py` with functions to:
   - Load and validate JSON input
   - Extract and structure top-level fields (parameters, resources, schemas)
   - Identify resources with defined HTTP methods
   - Separate required and optional parameters
   - Resolve nested request/response schemas from $ref fields

- Added `calendar_metadata_schemas.py` with:
   - Pydantic models to enforce structure
   -  `SchemaResolver ` class for safe recursive schema resolution

- Logged warnings on malformed sections and unresolved references while allowing graceful fallback