### PR TITLE
Feature/export json to csv

### DIFF
--- a/python-api/app/.coveragerc
+++ b/python-api/app/.coveragerc
@@ -1,8 +1,8 @@
 # .coveragerc
 [run]
 omit =
-    app/integrations/google_calendar/tests/*
     */__init__.py
+    */tests/*
     tests/*
 
 [report]

--- a/python-api/app/core/logging.py
+++ b/python-api/app/core/logging.py
@@ -22,6 +22,10 @@ class InterceptHandler(logging.Handler):
     Loguru documentation: https://loguru.readthedocs.io/en/stable/overview.html#entirely-compatible-with-standard-logging
     """
     def emit(self, record: logging.LogRecord) -> None:
+        # Omit logs that come from pytest execution
+        if record.name.startswith("pytest") or "pytest" in record.pathname:
+            return
+
         # Get corresponding Loguru level if it exists
         try:
             level = logger.level(record.levelname).name
@@ -80,3 +84,5 @@ def configure_logging():
             )
     except Exception as e:
         logger.error(f"Failed to add log file sink: {e}")
+
+configure_logging()

--- a/python-api/app/integrations/google_calendar/convert_data_to_csv.py
+++ b/python-api/app/integrations/google_calendar/convert_data_to_csv.py
@@ -1,0 +1,49 @@
+import json
+import csv
+from loguru import logger
+from app.integrations.google_calendar.schemas.calendar_metadata_schemas import ApiMethod
+from app.integrations.google_calendar import fetch_calendar_api_data
+
+
+def convert_api_methods_to_csv(data: list[ApiMethod]) -> str:
+    """
+    Converts a list of ApiMethod schemas (dicts) to a CSV file.
+
+    Args:
+        data (list): List of ApiMethod schema dictionaries.
+        output_file (str): Output CSV file path.
+    """
+    filename = fetch_calendar_api_data.generate_file_name("calendar_api_discovery", "csv")
+    filepath = fetch_calendar_api_data.create_directory_if_not_exists(filename)
+
+    try:
+        if not data:
+            raise ValueError("No API method data provided for CSV export.")
+
+        column_names = list(dict(data[0]).keys())
+
+        with open(filepath, 'w', newline='', encoding='utf-8') as csv_file:
+            writer = csv.DictWriter(csv_file, fieldnames=column_names)
+            writer.writeheader()
+
+            for row_dict in data:
+                processed_row = {}
+                dict_data = row_dict.model_dump()
+
+                for key, value in dict_data.items():
+                    if not value:  # empty dicts or list will be ""
+                        processed_row[key] = ""
+                    elif isinstance(value, (dict, list)):
+                        # convert nested dictionaries into their str representation
+                        processed_row[key] = json.dumps(value)
+                    else:
+                        processed_row[key] = value
+                writer.writerow(processed_row)
+        logger.debug(f"{len(data)} API methods were successfully written to CSV at {filepath}")
+        return filepath
+    except IOError as ioe:
+        logger.error(f"IO error while writing to {filepath}: {ioe}")
+        raise
+    except Exception as err:
+        logger.error(f"Unexpected error during CSV conversion: {err}")
+        raise

--- a/python-api/app/integrations/google_calendar/fetch_calendar_api_data.py
+++ b/python-api/app/integrations/google_calendar/fetch_calendar_api_data.py
@@ -8,7 +8,6 @@ from urllib3.util import Retry
 from loguru import logger
 # local imports
 from app.core.config import settings
-from app.core.logging import configure_logging
 
 
 # Enable detailed urllib3 logging

--- a/python-api/app/integrations/google_calendar/parse_calendar_api_data.py
+++ b/python-api/app/integrations/google_calendar/parse_calendar_api_data.py
@@ -1,9 +1,8 @@
 import json
 from loguru import logger
-from typing import Optional
-from app.core.logging import configure_logging
+from typing import Optional, Tuple, Dict, Any, List
 from app.integrations.google_calendar.schemas.calendar_metadata_schemas import CalendarMetadataParents, ApiMethod, SchemaResolver
-from typing import Tuple, Dict, Any
+
 
 def load_file_data(json_path: str) -> dict:
     """
@@ -51,7 +50,7 @@ def extract_top_level_attributes(data: dict) -> CalendarMetadataParents:
     )
 
     if not parent_metadata.resources:
-        logger.warning("No resources found in API metadata. Ensure the metadata is correct.")
+        logger.error("No resources found in API metadata. Ensure the metadata is correct.")
         raise ValueError("No resources found in API metadata.")
 
     logger.debug("Extracted top-level attributes from API metadata.")
@@ -108,7 +107,7 @@ def get_api_resources_with_methods(parent_metadata: CalendarMetadataParents) -> 
     logger.debug(f"Found {len(resources_with_methods)} resources with methods.")
     return resources_with_methods
 
-def get_api_method_parameters(method_parameters: dict):
+def get_api_method_parameters(method_parameters: Dict[str, Any]) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
     """
     Extracts and categorizes API method parameters into required and optional 
     parameters lists.
@@ -143,8 +142,8 @@ def get_api_method_parameters(method_parameters: dict):
     if not method_parameters:
         return [], []
 
-    required_params = []
-    optional_params = []
+    required_params: List[Dict[str, Any]] = []
+    optional_params: List[Dict[str, Any]] = []
 
     for name, value in method_parameters.items():
         if not isinstance(value, dict):

--- a/python-api/app/integrations/google_calendar/tests/test_convert_data_to_csv.py
+++ b/python-api/app/integrations/google_calendar/tests/test_convert_data_to_csv.py
@@ -1,0 +1,77 @@
+import os
+import tempfile
+import csv
+import pytest
+from unittest import mock
+from app.integrations.google_calendar.convert_data_to_csv import convert_api_methods_to_csv
+
+class DummyApiMethod:
+    def __init__(self, **kwargs):
+        self._data = kwargs
+
+    def model_dump(self):
+        return self._data
+
+    def __iter__(self):
+        return iter(self._data.items())
+
+    def keys(self):
+        return self._data.keys()
+
+    def __getitem__(self, key):
+        return self._data[key]
+
+@pytest.fixture
+def dummy_methods():
+    return [
+        DummyApiMethod(
+            name="get",
+            description="a get endpoint",
+            parameters={"key": "100"},
+            extra=None
+        ),
+        DummyApiMethod(
+            name="post",
+            description="a post endpoint",
+            parameters={'key': 101, 'name': 'test name', 'price': 'test_price'},
+            extra=""
+        ),
+    ]
+
+@mock.patch("app.integrations.google_calendar.convert_data_to_csv.fetch_calendar_api_data.generate_file_name")
+@mock.patch("app.integrations.google_calendar.convert_data_to_csv.fetch_calendar_api_data.create_directory_if_not_exists")
+def test_convert_api_methods_to_csv_creates_csv(mock_create_dir, mock_gen_file, dummy_methods):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        csv_path = os.path.join(tmpdir, "test.csv")
+        mock_gen_file.return_value = "test.csv"
+        mock_create_dir.return_value = csv_path
+
+        result_path = convert_api_methods_to_csv(dummy_methods)
+        assert result_path == csv_path
+        assert os.path.exists(csv_path)
+
+        with open(csv_path, newline='', encoding='utf-8') as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+            assert len(rows) == 2
+            assert rows[0]["name"] == "get"
+            assert rows[1]["name"] == "post"
+            assert rows[0]["parameters"] == '{"key": "100"}'
+            assert rows[1]["parameters"] == '{"key": 101, "name": "test name", "price": "test_price"}'
+
+@mock.patch("app.integrations.google_calendar.convert_data_to_csv.fetch_calendar_api_data.generate_file_name")
+@mock.patch("app.integrations.google_calendar.convert_data_to_csv.fetch_calendar_api_data.create_directory_if_not_exists")
+def test_convert_api_methods_to_csv_empty_data_raises(mock_create_dir, mock_gen_file):
+    mock_gen_file.return_value = "test.csv"
+    mock_create_dir.return_value = "test.csv"
+    with pytest.raises(ValueError, match="No API method data provided for CSV export."):
+        convert_api_methods_to_csv([])
+
+@mock.patch("app.integrations.google_calendar.convert_data_to_csv.fetch_calendar_api_data.generate_file_name")
+@mock.patch("app.integrations.google_calendar.convert_data_to_csv.fetch_calendar_api_data.create_directory_if_not_exists")
+def test_convert_api_methods_to_csv_ioerror(mock_create_dir, mock_gen_file, dummy_methods):
+    mock_gen_file.return_value = "test.csv"
+    mock_create_dir.return_value = "/invalid/path/test.csv"
+    with mock.patch("builtins.open", side_effect=IOError("disk full")):
+        with pytest.raises(IOError):
+            convert_api_methods_to_csv(dummy_methods)


### PR DESCRIPTION
## What?
- convert the parsed API metadata  from the Google Calendar  into a CSV format file.
- The core logic was added to `convert_data_to_csv.py.`
- Add unit tests with 100% test coverage for this module.

## Why?
- to output a clean, structured .csv file listing all API methods and their rquired data
- Having the data in CSV format allows for better inspection for future integrations
- Test coverage gives confidence in the implemented feature

## How?
- Add `convert_api_methods_to_csv` method in `convert_data_to_csv.py`, this method:
- Generates  and saves CSV File
- Add logs for succesfull and error operations
- Wrote unit tests for CSV generation with mock datato  avoid external dependencies.
- Avoid to write logs that comes from pytest execution on the `LOGS_FILE`.
