### PR TITLE
Feat/add main entry point script

### DIFF
--- a/python-api/.coveragerc
+++ b/python-api/.coveragerc
@@ -4,6 +4,8 @@ omit =
     */__init__.py
     */tests/*
     tests/*
+    integrations/google_calendar/tests/*
+    integrations/google_calendar/__init__.py
 
 [report]
 exclude_lines =

--- a/python-api/app/core/logging.py
+++ b/python-api/app/core/logging.py
@@ -85,4 +85,7 @@ def configure_logging():
     except Exception as e:
         logger.error(f"Failed to add log file sink: {e}")
 
+# Enable detailed urllib3 logging
+logging.getLogger("urllib3").setLevel(settings.LOGS_LEVEL)
+
 configure_logging()

--- a/python-api/app/integrations/google_calendar/convert_data_to_csv.py
+++ b/python-api/app/integrations/google_calendar/convert_data_to_csv.py
@@ -7,12 +7,24 @@ from app.integrations.google_calendar import fetch_calendar_api_data
 
 def convert_api_methods_to_csv(data: list[ApiMethod]) -> str:
     """
-    Converts a list of ApiMethod schemas (dicts) to a CSV file.
+    Converts a list of ApiMethod objects (endpoints metadata) to a CSV file.
+
+    This function takes a list of ApiMethod instances, processes each object
+    and writes the data to a CSV file.
+    The CSV file is created in /data directory and the file path is returned.
 
     Args:
-        data (list): List of ApiMethod schema dictionaries.
-        output_file (str): Output CSV file path.
+        data (list[ApiMethod]): A list of ApiMethod objects to be exported to CSV.
+
+    Returns:
+        str: The file path to the generated CSV file.
+
+    Raises:
+        ValueError: If the input data list is empty.
+        IOError: If an I/O error occurs while writing the file.
+        Exception: For any other unexpected errors during the CSV conversion process.
     """
+    
     filename = fetch_calendar_api_data.generate_file_name("calendar_api_discovery", "csv")
     filepath = fetch_calendar_api_data.create_directory_if_not_exists(filename)
 
@@ -39,10 +51,10 @@ def convert_api_methods_to_csv(data: list[ApiMethod]) -> str:
                     else:
                         processed_row[key] = value
                 writer.writerow(processed_row)
-        logger.debug(f"{len(data)} API methods were successfully written to CSV at {filepath}")
+        logger.debug(f"{len(data)} API methods were successfully written to CSV {filename}")
         return filepath
     except IOError as ioe:
-        logger.error(f"IO error while writing to {filepath}: {ioe}")
+        logger.error(f"IO error while writing to {filename}: {ioe}")
         raise
     except Exception as err:
         logger.error(f"Unexpected error during CSV conversion: {err}")

--- a/python-api/app/integrations/google_calendar/fetch_calendar_api_data.py
+++ b/python-api/app/integrations/google_calendar/fetch_calendar_api_data.py
@@ -6,12 +6,6 @@ import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util import Retry
 from loguru import logger
-# local imports
-from app.core.config import settings
-
-
-# Enable detailed urllib3 logging
-logging.getLogger("urllib3").setLevel(settings.LOGS_LEVEL)
 
 
 def create_retry_strategy() -> Retry:
@@ -181,8 +175,11 @@ def save_api_json_data(data: dict) -> str | None:
 
         with open(filepath, "w") as f:
             json.dump(data, f, indent=2)
+            # allows the file to be available before return
+            f.flush()
+            os.fsync(f.fileno())
 
-        logger.info(f"Google Calendar API metadata saved to {filepath}.")
+        logger.debug(f"Google Calendar API metadata saved on file {filename}.")
         return filepath
     except IOError as file_err:
         logger.error(f"Unexpected error occurred while saving API metadata to file: {file_err}")

--- a/python-api/app/integrations/google_calendar/main_entry_point.py
+++ b/python-api/app/integrations/google_calendar/main_entry_point.py
@@ -1,0 +1,139 @@
+from pprint import pformat
+from loguru import logger
+from typing import List, Optional
+from app.core.config import settings
+from app.integrations.google_calendar.schemas.calendar_metadata_schemas import ApiMethod, \
+    SchemaResolver
+from app.integrations.google_calendar.fetch_calendar_api_data import create_session, \
+    create_retry_strategy, fetch_api_metadata, save_api_json_data
+from app.integrations.google_calendar.parse_calendar_api_data import load_file_data, \
+    extract_top_level_attributes, get_api_resources_with_methods, get_api_methods
+from app.integrations.google_calendar.convert_data_to_csv import convert_api_methods_to_csv
+
+
+def fetch_api_data() -> str | None:
+    """
+    Fetches the Google Calendar API Discovery metadata and saves
+    it to a local JSON file.
+
+    This function performs the following steps:
+    1. Creates a `requests.Session` with retry logic and exponential backoff.
+    2. Sends a GET request to the Google Calendar Discovery API.
+    3. Saves the response JSON to a timestamped file in the local directory.
+
+    Returns:
+        str | None: The absolute file path of the saved JSON file if successful;
+        otherwise, None.
+
+    Raises:
+        Exception: If any unexpected error occurs during the fetch or save process.
+
+    Logs:
+        - Debug information about the request and file creation.
+        - Errors related to network issues or file system failures.
+    """
+    try:
+        session = create_session(create_retry_strategy())
+
+        data = fetch_api_metadata(session, settings.GOOGLE_CALENDAR_API_URL)
+        if not data:
+            return None
+
+        json_path = save_api_json_data(data)
+        if not json_path:
+            return None
+
+        return json_path
+    except Exception as err:
+        logger.error(f"An Error has ocurred while fetching and saving json data process: {err}")
+        raise
+
+def parse_data(json_path: str) -> Optional[List[ApiMethod]]:
+    """
+    Parses the Google Calendar API JSON into structured API method objects.
+
+    This function performs the following steps:
+    1. Loads the JSON file from the given path.
+    2. Extracts the top-level attributes (`parameters`, `schemas`, `resources`).
+    3. Resolves all `$ref` references in the schema definitions.
+    4. Iterates over API resources and their methods to construct `ApiMethod` objects.
+
+    Args:
+        json_path (str): The absolute path to the saved Google Calendar JSON file.
+
+    Returns:
+        Optional[List[ApiMethod]]: A list of parsed `ApiMethod` instances, or None if parsing fails.
+
+    Raises:
+        Exception: If any error occurs during file loading, schema resolution, or method parsing.
+
+    Logs:
+        - Error messages with contextual information if parsing fails at any stage.
+    """
+    try:
+        data = load_file_data(json_path)
+        parent_metadata = extract_top_level_attributes(data)
+        schemas_resolver = SchemaResolver(schemas=parent_metadata.schemas)
+        schemas_resolver.resolve_all()
+
+        resources_with_methods = get_api_resources_with_methods(parent_metadata)
+        api_methods = get_api_methods(resources_with_methods, schemas_resolver)
+
+        return api_methods
+    except Exception as e:
+        logger.error(f"Error in parse_data: {e}.")
+        raise
+
+def main_entry_point_function() -> Optional[dict]:
+    """
+    Executes the full process for fetching, parsing, and saving Google Calendar API metadata.
+
+    This function coordinates the following steps:
+    1. Fetches the Google Calendar API document and saves it as a local JSON file.
+    2. Parses the saved JSON to extract structured API method metadata using Pydantic models.
+    3. Converts the parsed API metadata into a CSV file for easy analysis.
+
+    Returns:
+        dict | None: A dictionary with output file paths and method count if successful,
+            otherwise None.
+
+    Logs:
+        - Warnings if no API methods are found after parsing.
+        - Errors if any step in the process fails.
+        - Final summary with output file paths and method count.
+
+    Notes:
+        - Uses robust error handling to ensure that each phase fails gracefully.
+        - Logs structured results for easy traceability and debugging.
+        - Can be exposed as a CLI entry point via `if __name__ == "__main__"` or `typer` integration.
+    """
+    try:
+        json_save_path: str = fetch_api_data()
+        if not json_save_path:
+            logger.error("JSON save path is None. Halting execution.")
+            return None
+
+        parsed_api_methods: List[ApiMethod] = parse_data(json_path=json_save_path)
+
+        if not parsed_api_methods:
+            logger.warning("No API methods parsed. CSV file will not be created.")
+            return None
+
+        csv_save_path: str = convert_api_methods_to_csv(data=parsed_api_methods)
+
+        response = {
+            "json_save_path": json_save_path,
+            "total_count_api_methods": len(parsed_api_methods),
+            "csv_save_path": csv_save_path
+        }
+
+        logger.debug(f"Process ends succesfully, see response metadata for the save files")
+        logger.info(f"Response:\n{pformat(response)}")
+
+        return response
+    except Exception:
+        return None
+
+
+if __name__ == "__main__":
+    main_entry_point_function()

--- a/python-api/app/integrations/google_calendar/tests/test_main_entry_point.py
+++ b/python-api/app/integrations/google_calendar/tests/test_main_entry_point.py
@@ -1,0 +1,213 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from app.integrations.google_calendar.main_entry_point import fetch_api_data, \
+    parse_data, main_entry_point_function
+
+
+@patch("app.integrations.google_calendar.main_entry_point.create_session")
+@patch("app.integrations.google_calendar.main_entry_point.create_retry_strategy")
+@patch("app.integrations.google_calendar.main_entry_point.fetch_api_metadata")
+@patch("app.integrations.google_calendar.main_entry_point.save_api_json_data")
+def test_fetch_api_data_success(mock_save, mock_fetch, mock_retry, mock_session):
+    mock_session.return_value = MagicMock()
+    mock_retry.return_value = MagicMock()
+    mock_fetch.return_value = {"test_key": "test_value"}
+    mock_save.return_value = "/tmp/test.json"
+
+    result = fetch_api_data()
+
+    assert result == "/tmp/test.json"
+    mock_session.assert_called_once()
+    mock_fetch.assert_called_once()
+    mock_save.assert_called_once()
+
+@patch("app.integrations.google_calendar.main_entry_point.create_session")
+@patch("app.integrations.google_calendar.main_entry_point.create_retry_strategy")
+@patch("app.integrations.google_calendar.main_entry_point.fetch_api_metadata")
+def test_fetch_api_data_fetch_returns_none(mock_fetch, mock_retry, mock_session):
+    mock_session.return_value = MagicMock()
+    mock_retry.return_value = MagicMock()
+    mock_fetch.return_value = None
+
+    result = fetch_api_data()
+
+    assert result is None
+
+@patch("app.integrations.google_calendar.main_entry_point.create_session")
+@patch("app.integrations.google_calendar.main_entry_point.create_retry_strategy")
+@patch("app.integrations.google_calendar.main_entry_point.fetch_api_metadata")
+@patch("app.integrations.google_calendar.main_entry_point.save_api_json_data")
+def test_fetch_api_data_save_returns_none(mock_save, mock_fetch, mock_retry, mock_session):
+    mock_session.return_value = MagicMock()
+    mock_retry.return_value = MagicMock()
+    mock_fetch.return_value = {"test_key": "test_value"}
+    mock_save.return_value = None
+
+    result = fetch_api_data()
+
+    assert result is None
+
+@patch("app.integrations.google_calendar.main_entry_point.create_session")
+@patch("app.integrations.google_calendar.main_entry_point.create_retry_strategy")
+@patch("app.integrations.google_calendar.main_entry_point.fetch_api_metadata")
+@patch("app.integrations.google_calendar.main_entry_point.save_api_json_data")
+def test_fetch_api_data_raises_exception(mock_save, mock_fetch, mock_retry, mock_session):
+    mock_session.side_effect = Exception("session error")
+
+    with pytest.raises(Exception) as excinfo:
+        fetch_api_data()
+
+    assert "session error" in str(excinfo.value)
+    @patch("app.integrations.google_calendar.main_entry_point.load_file_data")
+    @patch("app.integrations.google_calendar.main_entry_point.extract_top_level_attributes")
+    @patch("app.integrations.google_calendar.main_entry_point.SchemaResolver")
+    @patch("app.integrations.google_calendar.main_entry_point.get_api_resources_with_methods")
+    @patch("app.integrations.google_calendar.main_entry_point.get_api_methods")
+    def test_parse_data_success(
+        mock_get_api_methods,
+        mock_get_api_resources_with_methods,
+        mock_schema_resolver,
+        mock_extract_top_level_attributes,
+        mock_load_file_data
+    ):
+        mock_load_file_data.return_value = {"test_key": "test_value"}
+        mock_parent_metadata = MagicMock()
+        mock_extract_top_level_attributes.return_value = mock_parent_metadata
+
+        mock_resolver_instance = MagicMock()
+        mock_schema_resolver.return_value = mock_resolver_instance
+
+        mock_resources_with_methods = MagicMock()
+        mock_get_api_resources_with_methods.return_value = mock_resources_with_methods
+
+        expected_methods = [MagicMock(), MagicMock()]
+        mock_get_api_methods.return_value = expected_methods
+
+        result = parse_data("dummy_path.json")
+
+        mock_load_file_data.assert_called_once_with("dummy_path.json")
+        mock_extract_top_level_attributes.assert_called_once_with(mock_load_file_data.return_value)
+        mock_schema_resolver.assert_called_once_with(schemas=mock_parent_metadata.schemas)
+        mock_resolver_instance.resolve_all.assert_called_once()
+        mock_get_api_resources_with_methods.assert_called_once_with(mock_parent_metadata)
+        mock_get_api_methods.assert_called_once_with(mock_resources_with_methods, mock_resolver_instance)
+        assert result == expected_methods
+
+@patch("app.integrations.google_calendar.main_entry_point.load_file_data")
+@patch("app.integrations.google_calendar.main_entry_point.extract_top_level_attributes")
+@patch("app.integrations.google_calendar.main_entry_point.SchemaResolver")
+@patch("app.integrations.google_calendar.main_entry_point.get_api_resources_with_methods")
+@patch("app.integrations.google_calendar.main_entry_point.get_api_methods")
+def test_parse_data_returns_none_when_no_methods(
+    mock_get_api_methods,
+    mock_get_api_resources_with_methods,
+    mock_schema_resolver,
+    mock_extract_top_level_attributes,
+    mock_load_file_data
+):
+    mock_load_file_data.return_value = {"test_key": "test_value"}
+    mock_parent_metadata = MagicMock()
+    mock_extract_top_level_attributes.return_value = mock_parent_metadata
+
+    mock_resolver_instance = MagicMock()
+    mock_schema_resolver.return_value = mock_resolver_instance
+
+    mock_resources_with_methods = MagicMock()
+    mock_get_api_resources_with_methods.return_value = mock_resources_with_methods
+
+    mock_get_api_methods.return_value = []
+
+    result = parse_data("dummy_path.json")
+
+    assert result == []
+
+@patch("app.integrations.google_calendar.main_entry_point.load_file_data")
+def test_parse_data_raises_exception_on_load_file_data_error(mock_load_file_data):
+    mock_load_file_data.side_effect = Exception("file error")
+    with pytest.raises(Exception) as excinfo:
+        parse_data("dummy_path.json")
+    assert "file error" in str(excinfo.value)
+
+@patch("app.integrations.google_calendar.main_entry_point.load_file_data")
+@patch("app.integrations.google_calendar.main_entry_point.extract_top_level_attributes")
+@patch("app.integrations.google_calendar.main_entry_point.SchemaResolver")
+@patch("app.integrations.google_calendar.main_entry_point.get_api_resources_with_methods")
+@patch("app.integrations.google_calendar.main_entry_point.get_api_methods")
+def test_parse_data_raises_exception_on_get_api_methods_error(
+    mock_get_api_methods,
+    mock_get_api_resources_with_methods,
+    mock_schema_resolver,
+    mock_extract_top_level_attributes,
+    mock_load_file_data
+):
+    mock_load_file_data.return_value = {"test_key": "test_value"}
+    mock_parent_metadata = MagicMock()
+    mock_extract_top_level_attributes.return_value = mock_parent_metadata
+    mock_schema_resolver.return_value = MagicMock()
+    mock_get_api_resources_with_methods.return_value = MagicMock()
+    mock_get_api_methods.side_effect = Exception("methods error")
+
+    with pytest.raises(Exception) as excinfo:
+        parse_data("dummy_path.json")
+    assert "methods error" in str(excinfo.value)
+
+@patch("app.integrations.google_calendar.main_entry_point.convert_api_methods_to_csv")
+@patch("app.integrations.google_calendar.main_entry_point.parse_data")
+@patch("app.integrations.google_calendar.main_entry_point.fetch_api_data")
+def test_main_entry_point_success(mock_fetch_api_data, mock_parse_data, mock_convert_to_csv):
+    mock_fetch_api_data.return_value = "/tmp/test.json"
+    mock_methods = [MagicMock(), MagicMock()]
+    mock_parse_data.return_value = mock_methods
+    mock_convert_to_csv.return_value = "/tmp/test.csv"
+
+
+    result = main_entry_point_function()
+
+    assert result["json_save_path"] == "/tmp/test.json"
+    assert result["total_count_api_methods"] == 2
+    assert result["csv_save_path"] == "/tmp/test.csv"
+    mock_fetch_api_data.assert_called_once()
+    mock_parse_data.assert_called_once_with(json_path="/tmp/test.json")
+    mock_convert_to_csv.assert_called_once_with(data=mock_methods)
+
+@patch("app.integrations.google_calendar.main_entry_point.fetch_api_data")
+def test_main_entry_point_returns_none_when_fetch_api_data_none(mock_fetch_api_data):
+    mock_fetch_api_data.return_value = None
+
+
+    result = main_entry_point_function()
+    assert result is None
+    mock_fetch_api_data.assert_called_once()
+
+@patch("app.integrations.google_calendar.main_entry_point.parse_data")
+@patch("app.integrations.google_calendar.main_entry_point.fetch_api_data")
+def test_main_entry_point_returns_none_when_parse_data_returns_none(mock_fetch_api_data, mock_parse_data):
+    mock_fetch_api_data.return_value = "/tmp/test.json"
+    mock_parse_data.return_value = None
+
+
+    result = main_entry_point_function()
+    assert result is None
+    mock_fetch_api_data.assert_called_once()
+    mock_parse_data.assert_called_once_with(json_path="/tmp/test.json")
+
+@patch("app.integrations.google_calendar.main_entry_point.parse_data")
+@patch("app.integrations.google_calendar.main_entry_point.fetch_api_data")
+def test_main_entry_point_returns_none_when_parse_data_returns_empty_list(mock_fetch_api_data, mock_parse_data):
+    mock_fetch_api_data.return_value = "/tmp/test.json"
+    mock_parse_data.return_value = []
+
+
+    result = main_entry_point_function()
+    assert result is None
+    mock_fetch_api_data.assert_called_once()
+    mock_parse_data.assert_called_once_with(json_path="/tmp/test.json")
+
+@patch("app.integrations.google_calendar.main_entry_point.convert_api_methods_to_csv")
+@patch("app.integrations.google_calendar.main_entry_point.parse_data")
+@patch("app.integrations.google_calendar.main_entry_point.fetch_api_data")
+def test_main_entry_point_returns_none_on_exception(mock_fetch_api_data, mock_parse_data, mock_convert_to_csv):
+    mock_fetch_api_data.side_effect = Exception("fetch error")
+
+    result = main_entry_point_function()
+    assert result is None


### PR DESCRIPTION
## What?
- Add a `main_entry_point.py` file to execute the complete Google Calendar API metadata processing:
    - Fetch the metadata from the Google Calendar API.
    - Saved the raw response to a local .json file with timestamp
    - Parse the data into objects
    - Convert the parsed data into a CSV output file.
- add unit tests covering 100% of the logic for this feature.

## Why?
This entry point provides the execution path for the entire process.

## How?
- Implemented `main_entry_poin_function()` to sequence the process steps.
- Returns a structured metadata dictionary with file paths and processed API methods count.
- Add unit main_entry_point functions.

